### PR TITLE
fix issue #100 

### DIFF
--- a/src/test/resources/testModels/libraries/ETL_test/CheckOver.crml
+++ b/src/test/resources/testModels/libraries/ETL_test/CheckOver.crml
@@ -16,7 +16,7 @@ model CheckOver is {
 		
 	// Example of function call
 	Boolean phi1 is external;
-	Period P1 is external;
+	Periods P1 is external;
 			
 	Boolean b_check_over is 'check' phi1 'over' P1;
 };

--- a/src/test/resources/testModels/libraries/ETL_test/CheckOver_no_ext.crml
+++ b/src/test/resources/testModels/libraries/ETL_test/CheckOver_no_ext.crml
@@ -17,7 +17,7 @@ model CheckOver_no_ext is {
 	// Example of function call
 	Boolean phi1 is if (2.0 < time) and (time < 3.5) then undecided else false;
 	Boolean b1 is if (2.5 < time) and (time < 5) then true else false;
-	Period P1 is [new Event b1, new Event not b1];
+	Periods P1 is {[new Event b1, new Event not b1]};
 					
 	Boolean b_check_over is 'check' phi1 'over' P1; //Value is undefined, becomes undecided at 2.5s and then false at t=3.5s
 };


### PR DESCRIPTION
Closes issue #100.
Error was due to the CRML source code and not the generated one (requested input should not be defined as a single Period but as a set of Periods)